### PR TITLE
LoadBlessed=0 should not result in blessing data

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,7 @@
+[** NEXT **]
+
+* Make sure that LoadBlessed do not bless references when set to 0.
+
 [Changes for 1.22 - 2012-12-04]
 
 * Tests all green on CPAN Testers. releasing to public.

--- a/MANIFEST
+++ b/MANIFEST
@@ -28,6 +28,7 @@ lib/YAML/Loader/Syck.pm
 lib/YAML/Syck.pm
 Makefile.PL
 MANIFEST			This list of files
+META.json
 META.yml
 node.c
 perl_common.h
@@ -64,6 +65,7 @@ t/json-numbers.t
 t/json-refs.t
 t/json-singlequote.t
 t/leak.t
+t/load-blessed.t
 t/meta.t
 t/TestYAML.pm
 t/yaml-alias.t
@@ -72,4 +74,5 @@ t/yaml-dumpinto.t
 t/yaml-implicit-warnings.t
 t/yaml-str-colon-first.t
 t/yaml-tie.t
+t/yaml-utf.t
 token.c

--- a/t/load-blessed.t
+++ b/t/load-blessed.t
@@ -1,0 +1,70 @@
+use t::TestYAML tests => 11;
+
+ok( YAML::Syck->VERSION );
+
+my @tests = (
+    {
+        msg    => 'scalar',
+        object => sub {
+            my $str = "Hello";
+            return \$str;
+        },
+        loadblessed_enabled  => 'SCALAR',
+        loadblessed_disabled => 'SCALAR',
+    },
+
+    {
+        msg    => 'scalar blessed as object',
+        object => sub {
+            my $str = "Hello";
+            return bless \$str, "OBJ_STR";
+        },
+        loadblessed_enabled  => 'OBJ_STR',
+        loadblessed_disabled => 'SCALAR',
+    },
+    {
+        msg    => 'array ref blessed as object',
+        object => sub {
+            my $ar = [ 'hello', 'world' ];
+            return bless $ar, "OBJ_ARRAY";
+        },
+        loadblessed_enabled  => 'OBJ_ARRAY',
+        loadblessed_disabled => 'ARRAY',
+    },
+    {
+        msg    => 'regexp blessed as object',
+        object => sub {
+            my $regex = qr(xxyy);
+            return bless $regex, "MY_REGEXP";
+        },
+        loadblessed_enabled  => 'MY_REGEXP',
+        loadblessed_disabled => 'Regexp',
+        perl_version         => 5.008
+    },
+    {
+        msg    => 'code blessed as object',
+        object => sub {
+            my $code = sub { return localtime() };
+            return bless $code, "MY_CODE";
+        },
+        loadblessed_enabled  => 'MY_CODE',
+        loadblessed_disabled => 'CODE',
+    }
+);
+
+foreach my $t (@tests) {
+  SKIP: {
+        Test::More::skip "only for perl >= $t->{perl_version}", 2
+          if $t->{perl_version} && $] < $t->{perl_version};
+
+        $YAML::Syck::LoadBlessed = 1;
+        is ref Load( Dump( $t->{object}->() ) ) => $t->{loadblessed_enabled},
+          "$t->{msg} [ LoadBlessed = 1 ]";
+
+        $YAML::Syck::LoadBlessed = 0;
+        is ref Load( Dump( $t->{object}->() ) ) => $t->{loadblessed_disabled},
+          "$t->{msg} [ LoadBlessed = 0 ]";
+    }
+}
+
+exit;


### PR DESCRIPTION
When loading a reference to a code, regex, array or scalar
sv_bless was used whatever the value of LoadBlessed.

That commit make sure that nothing is blessed when
LoadBlessed = 0.
