### PR TITLE
Fixed JSON circular reference handling.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,8 @@
+[Changes for 1.24_01 - 2013-02-26]
+
+* Implement $JSON::Syck::MaxDepth
+* Prevent failure when the same object is seen twice during Dump.
+
 [Changes for 1.23 - 2013-02-26]
 
 * Tests all green on CPAN Testers. releasing to public.

--- a/emitter.c
+++ b/emitter.c
@@ -122,6 +122,8 @@ syck_new_emitter()
     e->best_width = 80;
     e->style = scalar_none;
     e->stage = doc_open;
+    e->depth = 0;
+    e->max_depth = 512;
     e->indent = 2;
     e->level = -1;
     e->anchors = NULL;
@@ -1348,8 +1350,9 @@ syck_emitter_mark_node( SyckEmitter *e, st_data_t n )
             st_insert( e->anchors, (st_data_t)oid, (st_data_t)anchor_name );
         }
 
+        /* XXX - Removed by BDRACO as the perl_syck.h now has a max_depth - XXX */
+        /* return 0; */
         /* XXX - Added by Audrey Tang to handle self-recursive structures - XXX */
-        return 0;
     }
     return oid;
 }

--- a/lib/JSON/Syck.pm
+++ b/lib/JSON/Syck.pm
@@ -60,6 +60,7 @@ sub DumpInto {
 }
 
 $JSON::Syck::ImplicitTyping  = 1;
+$JSON::Syck::MaxDepth        = 512;
 $JSON::Syck::Headless        = 1;
 $JSON::Syck::ImplicitUnicode = 0;
 $JSON::Syck::SingleQuote     = 0;
@@ -141,6 +142,13 @@ as in:
   JSON (UTF-8 flagged) => Perl (UTF-8 flagged)
   Perl (UTF-8 bytes)   => JSON (UTF-8 flagged)
   Perl (UTF-8 flagged) => JSON (UTF-8 flagged)
+
+By default, JSON::Syck::Dump will only transverse up to 512 levels of
+a datastructure in order to avoid an infinite loop when it is
+presented with an circular reference.
+
+However, you set C<$JSON::Syck::MaxLevels> to a larger value if you
+have very complex structures.
 
 Unfortunately, there's no implicit way to dump Perl UTF-8 flagged data
 structure to utf-8 encoded JSON. To do this, simply use Encode module, e.g.:

--- a/syck.h
+++ b/syck.h
@@ -349,6 +349,8 @@ struct _syck_emitter {
     SyckLevel *levels;
     int lvl_idx;
     int lvl_capa;
+    int max_depth;
+    int depth;
     /* Pointer for extension's use */
     void *bonus;
 };

--- a/t/json-circular-ref.t
+++ b/t/json-circular-ref.t
@@ -24,14 +24,11 @@ use JSON::Syck;
     like( $@, qr/^Dumping circular structures is not supported with JSON::Syck/, "Die is thrown when the circular ref happens" );
 }
 
-TODO: {
-    local $TODO = "There's no reason this shouldn't work. JSON::Syck should be able to dump duplicate pointers in a structure";
-
+{
     my $foo = {};
 
     my $result = eval { JSON::Syck::Dump( [ $foo, $foo ] ) };
-    isnt( $result, undef, "A Structure should come back on a JSON dump with duplicate references" );
+    isnt( $result, [ {}, {} ], "A Structure should come back on a JSON dump with duplicate references" );
     is( $@, '', "No die is thrown when the circular ref happens" );
-    diag explain $foo;
 }
 


### PR DESCRIPTION
Fix problem with the JSON emitter that caused JSON::Syck to
complain about circular references when it saw the same object
twice.

Added the $JSON::Syck::MaxDepth flag with a default value of 512
