### PR TITLE
Fix YAML generation to not permit marking of duplicate nodes.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,9 @@
-[Changes for 1.24_01 - 2013-02-26]
+[Changes for 1.24_02 - 2013-03-01]
+
+* Prevent YAML from being influnced by the previous
+  change
+
+[Changes for 1.24_01 - 2013-03-01]
 
 * Implement $JSON::Syck::MaxDepth
 * Prevent failure when the same object is seen twice during Dump.

--- a/META.yml
+++ b/META.yml
@@ -25,4 +25,4 @@ resources:
   homepage: http://search.cpan.org/dist/YAML-Syck
   license: http://opensource.org/licenses/mit-license.php
   repository: http://github.com/toddr/YAML-Syck
-version: 1.23
+version: 1.24_02

--- a/emitter.c
+++ b/emitter.c
@@ -1298,7 +1298,7 @@ void syck_emit_end( SyckEmitter *e )
  * soon-to-be-emitted tree.
  */
 SYMID
-syck_emitter_mark_node( SyckEmitter *e, st_data_t n )
+syck_emitter_mark_node( SyckEmitter *e, st_data_t n, int flags )
 {
     SYMID oid = 0;
     char *anchor_name = NULL;
@@ -1350,8 +1350,10 @@ syck_emitter_mark_node( SyckEmitter *e, st_data_t n )
             st_insert( e->anchors, (st_data_t)oid, (st_data_t)anchor_name );
         }
 
-        /* XXX - Removed by BDRACO as the perl_syck.h now has a max_depth - XXX */
-        /* return 0; */
+        /* XXX - Flag added by BDRACO as the perl_syck.h now has a max_depth - XXX */
+        if (! (flags & EMITTER_MARK_NODE_FLAG_PERMIT_DUPLICATE_NODES) ) {
+            return 0;
+        }
         /* XXX - Added by Audrey Tang to handle self-recursive structures - XXX */
     }
     return oid;

--- a/lib/JSON/Syck.pm
+++ b/lib/JSON/Syck.pm
@@ -5,7 +5,7 @@ use Exporter;
 use YAML::Syck ();
 
 BEGIN {
-    $VERSION   = '1.23';
+    $VERSION   = '1.24_02';
     @EXPORT_OK = qw( Load Dump LoadFile DumpFile DumpInto );
     @ISA       = 'Exporter';
     *Load      = \&YAML::Syck::LoadJSON;

--- a/lib/YAML/Syck.pm
+++ b/lib/YAML/Syck.pm
@@ -14,7 +14,7 @@ use 5.006;
 use Exporter;
 
 BEGIN {
-    $VERSION   = '1.23';
+    $VERSION   = '1.24_02';
     @EXPORT    = qw( Dump Load DumpFile LoadFile );
     @EXPORT_OK = qw( DumpInto );
     @ISA       = qw( Exporter );

--- a/perl_syck.h
+++ b/perl_syck.h
@@ -15,12 +15,14 @@
 #undef PERL_SYCK_EMITTER_HANDLER
 #undef PERL_SYCK_INDENT_LEVEL
 #undef PERL_SYCK_MARK_EMITTER
+#undef PERL_SYCK_EMITTER_MARK_NODE_FLAGS
 
 #ifdef YAML_IS_JSON
 #  define PACKAGE_NAME  "JSON::Syck"
 #  define NULL_LITERAL  "null"
 #  define NULL_LITERAL_LENGTH 4
 #  define SCALAR_NUMBER scalar_none
+#  define PERL_SYCK_EMITTER_MARK_NODE_FLAGS EMITTER_MARK_NODE_FLAG_PERMIT_DUPLICATE_NODES
 int json_max_depth = 512;
 char json_quote_char = '"';
 static enum scalar_style json_quote_style = scalar_2quote;
@@ -45,6 +47,7 @@ static enum scalar_style json_quote_style = scalar_2quote;
 #  define NULL_LITERAL  "~"
 #  define NULL_LITERAL_LENGTH 1
 #  define SCALAR_NUMBER scalar_none
+#  define PERL_SYCK_EMITTER_MARK_NODE_FLAGS 0
 static enum scalar_style yaml_quote_style = scalar_none;
 #  define SCALAR_STRING yaml_quote_style
 #  define SCALAR_QUOTED scalar_1quote
@@ -810,7 +813,7 @@ yaml_syck_mark_emitter
     e->depth++;
 #endif
 
-    if (syck_emitter_mark_node(e, (st_data_t)sv) == 0) {
+    if (syck_emitter_mark_node(e, (st_data_t)sv, PERL_SYCK_EMITTER_MARK_NODE_FLAGS) == 0) {
 #ifdef YAML_IS_JSON
         e->depth--;
 #endif
@@ -1252,10 +1255,10 @@ DumpYAMLImpl
     SV *sortkeys         = GvSV(gv_fetchpv(form("%s::SortKeys", PACKAGE_NAME), TRUE, SVt_PV));
 #ifdef YAML_IS_JSON
     SV *singlequote      = GvSV(gv_fetchpv(form("%s::SingleQuote", PACKAGE_NAME), TRUE, SVt_PV));
+    SV *max_depth        = GvSV(gv_fetchpv(form("%s::MaxDepth", PACKAGE_NAME), TRUE, SVt_PV));
     json_quote_char      = (SvTRUE(singlequote) ? '\'' : '"' );
     json_quote_style     = (SvTRUE(singlequote) ? scalar_2quote_1 : scalar_2quote );
     emitter->indent      = PERL_SYCK_INDENT_LEVEL;
-    SV *max_depth        = GvSV(gv_fetchpv(form("%s::MaxDepth", PACKAGE_NAME), TRUE, SVt_PV));
     emitter->max_depth   = SvIOK(max_depth) ? SvIV(max_depth) : json_max_depth;
 #else
     SV *singlequote      = GvSV(gv_fetchpv(form("%s::SingleQuote", PACKAGE_NAME), TRUE, SVt_PV));

--- a/syck.h
+++ b/syck.h
@@ -93,6 +93,8 @@ extern "C" {
 #define NL_CHOMP    40
 #define NL_KEEP     50
 
+#define EMITTER_MARK_NODE_FLAG_PERMIT_DUPLICATE_NODES 1
+
 /*
  * Node definitions
  */
@@ -394,7 +396,7 @@ long syck_io_str_read( char *, SyckIoStr *, long, long );
 char *syck_base64enc( char *, long );
 char *syck_base64dec( char *, long, long * );
 SyckEmitter *syck_new_emitter( void );
-SYMID syck_emitter_mark_node( SyckEmitter *, st_data_t );
+SYMID syck_emitter_mark_node( SyckEmitter *, st_data_t, int );
 void syck_emitter_ignore_id( SyckEmitter *, SYMID );
 void syck_output_handler( SyckEmitter *, SyckOutputHandler );
 void syck_emitter_handler( SyckEmitter *, SyckEmitterHandler );


### PR DESCRIPTION
Make previous commit ISO C compliant

Increment version number to 1.24_02

Sorry about the flags, however with the way perl_syck.h does the dual YAML / JSON, I can't do #ifdefs in emitter.c
