### PR TITLE
Resolve RT#84882 and RT#84466 hash randomisation in yaml-alias.t

### DIFF
--- a/t/yaml-alias.t
+++ b/t/yaml-alias.t
@@ -35,7 +35,7 @@ $undumped = { abc => {}, def => {} };
 $undumped->{abc}->{sibling} = $undumped->{def};
 $undumped->{def}->{sibling} = $undumped->{abc};
 $roundtripped               = Load( Dump($undumped) );
-is( Dump($roundtripped), Dump($undumped), "circular" );
+is_deeply( $roundtripped, $undumped, "circular" );
 
 $undumped->{def}->{sibling}     = {};
 $roundtripped->{def}->{sibling} = {};


### PR DESCRIPTION
Tested on 'This is perl 5, version 18, subversion 0 (v5.18.0) built for i386-freebsd-64int'
