### PR TITLE
Fix crash in syck_emit on platforms with long long pointers

### DIFF
--- a/emitter.c
+++ b/emitter.c
@@ -364,7 +364,6 @@ syck_emit( SyckEmitter *e, st_data_t n )
     SYMID oid;
     char *anchor_name = NULL;
     int indent = 0;
-    long x = 0;
     SyckLevel *parent;
     SyckLevel *lvl = syck_emitter_current_level( e );
     
@@ -406,7 +405,7 @@ syck_emit( SyckEmitter *e, st_data_t n )
             e->anchored = st_init_numtable();
         }
 
-        if ( ! st_lookup( e->anchored, (st_data_t)anchor_name, (st_data_t *)&x ) )
+        if ( ! st_lookup( e->anchored, (st_data_t)anchor_name, 0 ) )
         {
             char *an = S_ALLOC_N( char, strlen( anchor_name ) + 3 );
             sprintf( an, "&%s ", anchor_name );
@@ -420,8 +419,7 @@ syck_emit( SyckEmitter *e, st_data_t n )
             syck_emitter_write( e, an, strlen( anchor_name ) + 2 );
             free( an );
 
-            x = 1;
-            st_insert( e->anchored, (st_data_t)anchor_name, (st_data_t)x );
+            st_insert( e->anchored, (st_data_t)anchor_name, 0 );
             lvl->anctag = 1;
         }
         else

--- a/syck.h
+++ b/syck.h
@@ -39,6 +39,7 @@
 #endif
 
 #include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <ctype.h>
 #ifdef HAVE_ST_H
@@ -99,18 +100,10 @@ extern "C" {
  * Node definitions
  */
 #ifndef ST_DATA_T_DEFINED
-#ifdef MINGW64
-typedef long long st_data_t;
-#else
-typedef long st_data_t;
-#endif
+typedef uintptr_t st_data_t;
 #endif
 
-#ifdef MINGW64
-#define SYMID unsigned long long
-#else
-#define SYMID unsigned long
-#endif
+#define SYMID uintptr_t
 
 typedef struct _syck_node SyckNode;
 


### PR DESCRIPTION
This fixes [RT#83879](https://rt.cpan.org/Public/Bug/Display.html?id=83879). Strawberry Perl uses the 32-bit version of MinGW, so `MINGW64` is not defined. This replaces the pointer typedefs with `uintptr_t` from `stdint.h`. Another crash came from the fact that `syck_emit` had `st_lookup` write a `long long` to the `long x` which caused part of the `parent` pointer to be overwritten when a reference was being emitted. The `x` variable wasn't actually being used for anything, so I removed it. All tests are now passing on Windows 64-bit.
