### PR TITLE
Fixing RT #41141 -- handling carriage return after c-indicator.

### DIFF
--- a/emitter.c
+++ b/emitter.c
@@ -571,7 +571,7 @@ syck_scan_scalar( int req_width, char *cursor, long len )
     }
     if ( ( cursor[0] == '-' || cursor[0] == ':' ||
            cursor[0] == '?' || cursor[0] == ',' ) &&
-           ( cursor[1] == ' ' || cursor[1] == '\n' || len == 1 ) )
+           ( cursor[1] == ' ' || cursor[1] == '\n' || cursor[1] == '\r' || len == 1 ) )
     {
             flags |= SCAN_INDIC_S;
     }

--- a/t/bug/rt-41141.t
+++ b/t/bug/rt-41141.t
@@ -1,0 +1,22 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 1;
+use Test::Deep;
+
+use YAML::Syck;
+
+my $test_hash = {
+    test => "?\r",
+};
+
+my $yaml = YAML::Syck::Dump($test_hash);
+my $decoded = YAML::Syck::Load($yaml);
+cmp_deeply(
+    $decoded,
+    $test_hash,
+    'Produced YAML was successfully decoded'
+);
+

--- a/t/bug/rt-41141.t
+++ b/t/bug/rt-41141.t
@@ -3,20 +3,41 @@
 use strict;
 use warnings;
 
-use Test::More tests => 1;
+use Test::More;
 use Test::Deep;
 
 use YAML::Syck;
 
-my $test_hash = {
-    test => "?\r",
-};
-
-my $yaml = YAML::Syck::Dump($test_hash);
-my $decoded = YAML::Syck::Load($yaml);
-cmp_deeply(
-    $decoded,
-    $test_hash,
-    'Produced YAML was successfully decoded'
+my %tests = (
+    'ends with carriage return' => "?\r",
+    'number ends with carrier return' => "42\r",
 );
+
+plan tests => 3 * scalar keys %tests;
+while (my ($test, $value) = each (%tests))
+{
+    my $test_hash = { key => $value };
+    my $yaml = YAML::Syck::Dump($test_hash);
+    my $decoded = YAML::Syck::Load($yaml);
+
+    cmp_deeply(
+        $decoded,
+        $test_hash,
+        "hash: $test",
+    );
+
+    $yaml = YAML::Syck::Dump($value);
+    $decoded = YAML::Syck::Load($yaml);
+    is($value, $decoded, "scalar: $test");
+
+    $yaml = YAML::Syck::Dump([$value]);
+    $decoded = YAML::Syck::Load($yaml);
+    cmp_deeply(
+        [ $value ],
+        $decoded,
+        "array: $test",
+    );
+}
+
+note 'Done!';
 


### PR DESCRIPTION
This is a fix for https://rt.cpan.org/Public/Bug/Display.html?id=41141, which I ran into at work today. Basically

```
YAML::Syck::Dump({ test => "?\r"})
```

produced some invalid YAML, which took down my daemons when I tried decoding the data later.

Let me know if I did something wrong (I skimmed through http://yaml.org/spec/1.2/spec.html, but I'm hardly an expert), or if there's something more you need me to do before accepting the pull request.

Cheers!
