### PR TITLE
stdint.h is only available in C99

### DIFF
--- a/syck.h
+++ b/syck.h
@@ -39,7 +39,9 @@
 #endif
 
 #include <stddef.h>
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L && !defined(VMS)
 #include <stdint.h>
+#endif
 #include <stdio.h>
 #include <ctype.h>
 #ifdef HAVE_ST_H


### PR DESCRIPTION
This fixes a compile error with the Microsoft Visual Studio compiler.