### PR TITLE
Fix CHECK_UTF8 SEGV [cpan #61562]

### DIFF
--- a/perl_common.h
+++ b/perl_common.h
@@ -60,6 +60,7 @@ SV* perl_syck_lookup_sym( SyckParser *p, SYMID v) {
 #ifdef SvUTF8_on
 #define CHECK_UTF8 \
     if (((struct parser_xtra *)p->bonus)->implicit_unicode \
+      && n->data.str->len \
       && is_utf8_string((U8*)n->data.str->ptr, n->data.str->len)) \
         SvUTF8_on(sv);
 #else


### PR DESCRIPTION
Fix a SEGV detected on openbsd malloc (repro with M_PERTURB=1)
by omitting the check with a len=0 string.
