### PR TITLE
Release as 1.29_02

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,11 @@
+[Changes for 1.29_02 - 2016-03-03]
+
+* Fix handling carriage return after c-indicator RT 41141
+* Fix CHECK_UTF8 SEGV with empty len=0 strings RT 61562
+* Add missing function declarations
+* Tighten the TODO tests, no passing TODOs now. But still JSON
+  SingleQuote and \/ and \u roundtrips do fail.
+
 [Changes for 1.29_01 - 2014-12-14]
 
 * Experimentally try patch from RT 83825. Will release if no test failures or complaints.

--- a/META.yml
+++ b/META.yml
@@ -25,4 +25,4 @@ resources:
   homepage: http://search.cpan.org/dist/YAML-Syck
   license: http://opensource.org/licenses/mit-license.php
   repository: http://github.com/toddr/YAML-Syck
-version: '1.29_01'
+version: '1.29_02'

--- a/emitter.c
+++ b/emitter.c
@@ -571,7 +571,7 @@ syck_scan_scalar( int req_width, char *cursor, long len )
     }
     if ( ( cursor[0] == '-' || cursor[0] == ':' ||
            cursor[0] == '?' || cursor[0] == ',' ) &&
-           ( cursor[1] == ' ' || cursor[1] == '\n' || len == 1 ) )
+           ( cursor[1] == ' ' || cursor[1] == '\n' || cursor[1] == '\r' || len == 1 ) )
     {
             flags |= SCAN_INDIC_S;
     }

--- a/gram.c
+++ b/gram.c
@@ -90,8 +90,6 @@
 #define YAML_IEND 269
 
 
-
-
 /* Copy the first part of user declarations.  */
 #line 14 "gram.y"
 
@@ -135,6 +133,7 @@ typedef union YYSTYPE {
     SyckNode *nodeData;
     char *name;
 } YYSTYPE;
+
 /* Line 191 of yacc.c.  */
 #line 140 "gram.c"
 # define yystype YYSTYPE /* obsolescent; will be withdrawn */
@@ -142,6 +141,7 @@ typedef union YYSTYPE {
 # define YYSTYPE_IS_TRIVIAL 1
 #endif
 
+int sycklex( YYSTYPE *sycklval, SyckParser *parser );
 
 
 /* Copy the second part of user declarations.  */

--- a/gram.h
+++ b/gram.h
@@ -56,9 +56,6 @@
 #define YAML_INDENT 268
 #define YAML_IEND 269
 
-
-
-
 #if ! defined (YYSTYPE) && ! defined (YYSTYPE_IS_DECLARED)
 #line 35 "gram.y"
 typedef union YYSTYPE {
@@ -72,6 +69,8 @@ typedef union YYSTYPE {
 # define YYSTYPE_IS_DECLARED 1
 # define YYSTYPE_IS_TRIVIAL 1
 #endif
+
+int sycklex( YYSTYPE *sycklval, SyckParser *parser );
 
 
 

--- a/lib/JSON/Syck.pm
+++ b/lib/JSON/Syck.pm
@@ -5,7 +5,7 @@ use Exporter;
 use YAML::Syck ();
 
 BEGIN {
-    $VERSION   = '1.29_01';
+    $VERSION   = '1.29_02';
     @EXPORT_OK = qw( Load Dump LoadFile DumpFile DumpInto );
     @ISA       = 'Exporter';
     *Load      = \&YAML::Syck::LoadJSON;

--- a/lib/YAML/Syck.pm
+++ b/lib/YAML/Syck.pm
@@ -14,7 +14,7 @@ use 5.006;
 use Exporter;
 
 BEGIN {
-    $VERSION   = '1.29_01';
+    $VERSION   = '1.29_02';
     @EXPORT    = qw( Dump Load DumpFile LoadFile );
     @EXPORT_OK = qw( DumpInto );
     @ISA       = qw( Exporter );

--- a/perl_common.h
+++ b/perl_common.h
@@ -60,6 +60,7 @@ SV* perl_syck_lookup_sym( SyckParser *p, SYMID v) {
 #ifdef SvUTF8_on
 #define CHECK_UTF8 \
     if (((struct parser_xtra *)p->bonus)->implicit_unicode \
+      && n->data.str->len \
       && is_utf8_string((U8*)n->data.str->ptr, n->data.str->len)) \
         SvUTF8_on(sv);
 #else

--- a/syck.h
+++ b/syck.h
@@ -392,6 +392,7 @@ char *syck_match_implicit( char *, size_t );
  * API prototypes
  */
 char *syck_strndup( char *, long );
+int syck_str_is_unquotable_integer(char*, long);
 long syck_io_file_read( char *, SyckIoFile *, long, long );
 long syck_io_str_read( char *, SyckIoStr *, long, long );
 char *syck_base64enc( char *, long );

--- a/t/bug/rt-41141.t
+++ b/t/bug/rt-41141.t
@@ -1,0 +1,31 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Test::More;
+use YAML::Syck;
+use Data::Dumper;
+
+# Carrier returns after c-indicators aren't being handled properly.
+
+my %tests = (
+    # From the original bug report. Seems to have been fixed already.
+    '42\\r' => "42\r",
+
+    # These all produced bad YAML.
+    '?\\r'  => "?\r",
+    '-\\r\\r'  => "-\r\r",
+    ',\\r\\r\\r'  => ",\r\r\r",
+);
+
+plan tests => scalar keys %tests;
+while (my ($test, $value) = each (%tests))
+{
+    my $yaml = YAML::Syck::Dump($value);
+    my $decoded = eval { YAML::Syck::Load($yaml); };
+    is($decoded, $value, "Produces valid YAML: $test");
+}
+
+note 'Done!';
+

--- a/t/json-basic.t
+++ b/t/json-basic.t
@@ -42,14 +42,14 @@ my @tests = (
     '{"foo":""}',
     '["\"://\""]',
     '"~foo"',
-    { TEST => '"\/"', TODO => "backslashed char not working yet" },    # escaped solidus
+    { TEST => '"\/"',     TODO => "backslashed char not working yet" }, # escaped solidus
     '"\""',
     { TEST => '"\b"',     TODO => "backslashed char not working yet" },
     { TEST => '"\f"',     TODO => "backslashed char not working yet" },
     { TEST => '"\n"',     TODO => "backslashed char not working yet" },
     { TEST => '"\r"',     TODO => "backslashed char not working yet" },
-    { TEST => '"\t"',     TODO => "backslashed char not working yet" },
-    { TEST => '"\u0001"', TODO => "backslashed char not working yet" },
+    { TEST => '"\t"',     TODO => "backslashed \\t not working yet" },
+    { TEST => '"\u0001"', TODO => "backslashed \\u not working yet" },
 );
 
 plan tests => scalar @tests * ( 2 + $HAS_JSON ) * 2;
@@ -64,7 +64,9 @@ TODO: {
 
                 local $TODO;
                 if ( ref $test eq 'HASH' ) {
-                    $TODO = $test->{TODO};
+                    if ($single_quote or substr($test->{TEST},2,1) =~ m|[u/]|) {
+                        $TODO = $test->{TODO};
+                    }
                     $test = $test->{TEST};
                 }
 
@@ -84,7 +86,8 @@ TODO: {
                     s/([,:]) /$1/eg;
                 }
 
-                my $desc = "roundtrip $test -> " . Dumper($data) . " -> $json -> sq:$single_quote utf8:$unicode ";
+                my $desc = "roundtrip $test -> " . Dumper($data)
+                  . " -> $json -> sq:$single_quote utf8:$unicode ";
                 utf8::encode($desc);
                 is $json, $test, $desc;
 


### PR DESCRIPTION
or give me comaint.

There will be a lot more fixes coming up, and can easily tests it for all perl versions beforehand.

BTW: Comparing YAML::XS to YAML::Syck it's pretty clear to me now which library is the better one.
YAML::Syck is by far better written, has more features, and less bugs. YAML::XS violates the specs such that YAML::XS files cannot be read by YAML, and is very strict and fatal on errors. 
Some People might like strict errors on data violations and data loss, but we prefer to keep encoding or quoting errors around.

YAML::Suck supports native filehandle methods and iterations, YAML::XS can only do costly and primitive stringbuffers.
