### PR TITLE
fix ASAN heap-buffer-overflow with empty strings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,67 @@
+language: "perl"
+sudo: false
+perl:
+# - "5.6.2"
+  - "5.8"
+  - "5.10"
+  - "5.12"
+  - "5.14"
+  - "5.16"
+  - "5.18"
+  - "5.20"
+  - "5.22"
+  - "5.24"
+  - "5.24-thr"
+  - "5.24-dbg"
+  - "5.24-thr-dbg"
+  - "5.24-mb"
+  - "dev"
+# - "blead"
+
+# slows down already cached versions by 3 (33s => 1m45s)
+# (i.e. cache download: 9s, setup: 45s-130s)
+# but speeds up building the non-cached versions (5.24-*) by 2 (3m50s => 1m45s)
+# overall: 25min => 35min, so disable the perl cache
+#cache:
+#  directories:
+#    - /home/travis/perl5/perlbrew/
+
+#addons:
+#  apt:
+#    packages:
+#    - gperf
+
+# blead and 5.6 stumble over YAML and more missing dependencies
+# for Devel::Cover::Report::Coveralls
+# cpanm does not do 5.6
+before_install:
+  - mkdir /home/travis/bin || true
+  - ln -s `which true` /home/travis/bin/cpansign
+  - eval $(curl https://travis-perl.github.io/init) --auto
+install:
+  - export AUTOMATED_TESTING=1 HARNESS_TIMER=1 AUTHOR_TESTING=0 RELEASE_TESTING=0
+  - cpan-install --deps       # installs prereqs, including recommends
+  #- cpan-install JSON JSON::PP JSON::XS Mojo::JSON Test::LeakTrace Time::Piece
+  - cpan-install --coverage   # installs converage prereqs, if enabled
+
+before_script:
+  - coverage-setup
+
+notifications:
+  email:
+    on_success: change
+    on_failure: always
+
+matrix:
+  fast_finish: true
+  include:
+    - perl: "5.24"
+      env: COVERAGE=1 AUTHOR_TESTING=1  # enables coverage+coveralls reporting
+  allow_failures:
+    - env: COVERAGE=1 AUTHOR_TESTING=1
+    - perl: "dev"
+
+# Hack to not run on tag pushes:
+branches:
+  except:
+  - /^v?[0-9]+\.[0-9]+/

--- a/perl_common.h
+++ b/perl_common.h
@@ -60,6 +60,7 @@ SV* perl_syck_lookup_sym( SyckParser *p, SYMID v) {
 #ifdef SvUTF8_on
 #define CHECK_UTF8 \
     if (((struct parser_xtra *)p->bonus)->implicit_unicode \
+      && n->data.str->len \
       && is_utf8_string((U8*)n->data.str->ptr, n->data.str->len)) \
         SvUTF8_on(sv);
 #else


### PR DESCRIPTION
you cannot check is_utf8_string with an empty string, as len=0
will call strlen then, which is invalid on empty strings.

==67523==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x60b0000155a4 at pc 0x0001009f67a2 bp 0x7fff5fbfe110 sp 0x7fff5fbfd8d0
READ of size 101 at 0x60b0000155a4 thread T0
    #0 0x1009f67a1 in wrap_strlen (/opt/local/libexec/llvm-3.9/lib/libclang_rt.asan_osx_dynamic.dylib+0xf7a1)
    #1 0x1041549e0 in Perl_is_utf8_string /usr/local/lib/cperl/5.25.3/darwin-debug-asan@/CORE/inline.h:437:45
    #2 0x104153e59 in json_syck_parser_handler /Users/rurban/Perl/YAML-Syck/./perl_syck.h:176:21
    #3 0x10414a7a4 in syck_hdlr_add_node /Users/rurban/Perl/YAML-Syck/handler.c:19:17
    #4 0x104148077 in syckparse /Users/rurban/Perl/YAML-Syck/gram.y:58:43
    #5 0x104172011 in syck_parse /Users/rurban/Perl/YAML-Syck/syck_.c:492:5
    #6 0x10416c6fc in LoadJSON /Users/rurban/Perl/YAML-Syck/./perl_syck.h:788:13
    #7 0x10416c6fc in XS_YAML__Syck_LoadJSON /Users/rurban/Perl/YAML-Syck/Syck.c:258
    #8 0x100318f74 in Perl_pp_enterxssub (/usr/local/bin/cperl5.25.3d-nt-asan+0x100318f74)
    #9 0x1002698e3 in Perl_runops_debug (/usr/local/bin/cperl5.25.3d-nt-asan+0x1002698e3)
    #10 0x10009da88 in perl_run (/usr/local/bin/cperl5.25.3d-nt-asan+0x10009da88)
    #11 0x100000fec  (/usr/local/bin/cperl5.25.3d-nt-asan+0x100000fec)
    #12 0x7fff8171a5ac  (/usr/lib/system/libdyld.dylib+0x35ac)

0x60b0000155a4 is located 0 bytes to the right of 100-byte region [0x60b000015540,0x60b0000155a4)
allocated by thread T0 here:
    #0 0x100a3b485 in wrap_malloc (/opt/local/libexec/llvm-3.9/lib/libclang_rt.asan_osx_dynamic.dylib+0x54485)

SUMMARY: AddressSanitizer: heap-buffer-overflow (/opt/local/libexec/llvm-3.9/lib/libclang_rt.asan_osx_dynamic.dylib+0xf7a1) in wrap_strlen