### PR TITLE
perl-5.26.0 compatibility

### DIFF
--- a/t/11-loadfile.t
+++ b/t/11-loadfile.t
@@ -1,3 +1,4 @@
+use lib ".";
 use t::TestYAML;
 use Test::More;
 use FindBin '$RealBin';

--- a/t/12-dumpfile.t
+++ b/t/12-dumpfile.t
@@ -1,3 +1,4 @@
+use lib ".";
 use t::TestYAML;
 use Test::More;
 use FindBin '$RealBin';

--- a/t/2-scalars.t
+++ b/t/2-scalars.t
@@ -1,3 +1,4 @@
+use lib ".";
 use t::TestYAML tests => 134;
 
 ok( YAML::Syck->VERSION, "YAML::Syck has a version and is loaded" );

--- a/t/3-objects.t
+++ b/t/3-objects.t
@@ -1,3 +1,4 @@
+use lib ".";
 use t::TestYAML tests => 51,
   (
       ( $] < 5.008 )

--- a/t/4-perl_tag_scheme.t
+++ b/t/4-perl_tag_scheme.t
@@ -1,3 +1,4 @@
+use lib ".";
 use t::TestYAML tests => 18;
 
 ok( YAML::Syck->VERSION );

--- a/t/json-basic.t
+++ b/t/json-basic.t
@@ -1,4 +1,5 @@
 use strict;
+use lib ".";
 use t::TestYAML ();
 use Data::Dumper;
 use Test::More;

--- a/t/json-crlf.t
+++ b/t/json-crlf.t
@@ -1,4 +1,5 @@
 use strict;
+use lib ".";
 use t::TestYAML ();
 use Test::More tests => 6;
 

--- a/t/json-empty.t
+++ b/t/json-empty.t
@@ -1,4 +1,5 @@
 use strict;
+use lib ".";
 use t::TestYAML ();
 use Test::More tests => 1;
 use JSON::Syck;

--- a/t/json-indent.t
+++ b/t/json-indent.t
@@ -1,4 +1,5 @@
 use strict;
+use lib ".";
 use t::TestYAML ();
 use JSON::Syck;
 use Test::More tests => 1;

--- a/t/json-loadfile.t
+++ b/t/json-loadfile.t
@@ -1,3 +1,4 @@
+use lib ".";
 use t::TestYAML;
 use JSON::Syck;
 use Test::More;

--- a/t/json-minus.t
+++ b/t/json-minus.t
@@ -1,4 +1,5 @@
 use strict;
+use lib ".";
 use t::TestYAML ();
 use JSON::Syck;
 use Test::More tests => 1;

--- a/t/json-null.t
+++ b/t/json-null.t
@@ -1,4 +1,5 @@
 use strict;
+use lib ".";
 use t::TestYAML ();
 use Test::More tests => 2;
 

--- a/t/json-refs.t
+++ b/t/json-refs.t
@@ -1,4 +1,5 @@
 use strict;
+use lib ".";
 use t::TestYAML ();
 use JSON::Syck;
 use Test::More;

--- a/t/json-singlequote.t
+++ b/t/json-singlequote.t
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 
+use lib ".";
 use t::TestYAML ();
 use Test::More tests => 5;
 use JSON::Syck;

--- a/t/load-blessed.t
+++ b/t/load-blessed.t
@@ -1,3 +1,4 @@
+use lib ".";
 use t::TestYAML tests => 11;
 
 ok( YAML::Syck->VERSION );

--- a/t/yaml-blessed-ref.t
+++ b/t/yaml-blessed-ref.t
@@ -1,4 +1,5 @@
 use strict;
+use lib ".";
 use t::TestYAML tests => 1;
 use YAML::Syck;
 use Data::Dumper;

--- a/t/yaml-utf.t
+++ b/t/yaml-utf.t
@@ -3,6 +3,7 @@ use warnings;
 
 use utf8;
 
+use lib ".";
 use t::TestYAML ();
 use Test::More tests => 3;
 use YAML::Syck;


### PR DESCRIPTION
In perl 5.26.0, '.' will no longer be found by default in @INC.  This patch
adjusts tests to that t/TestYAML.pm is correctly located.

For:  https://rt.cpan.org/Ticket/Display.html?id=120433