### PR TITLE
Fix memory corruption error

### DIFF
--- a/handler.c
+++ b/handler.c
@@ -32,6 +32,16 @@ syck_hdlr_add_anchor( SyckParser *p, char *a, SyckNode *n )
 {
     SyckNode *ntmp = NULL;
 
+    if (n->anchor != NULL) {
+        /*
+         * Note: An error should be returned here. But this is better than
+         * not checking at all because it will abort the program with a
+         * memory corruption error.
+         * Happens if you have two anchors after each other or an anchor
+         * before an alias
+         * */
+        return n;
+    }
     n->anchor = a;
     if ( p->bad_anchors != NULL )
     {


### PR DESCRIPTION
See issue #44 

Currently the following examples abort the program:

```
"&anchor1 &anchor2 x"
double free or corruption (fasttop)

"- &anchor1 &anchor2 x"
double free or corruption (fasttop)

"x: &anchor1 &anchor2 x"
malloc(): memory corruption (fast)

"key1: &a value1
&b *a : value2"
double free or corruption (fasttop)
```

This fix will prevent the abort and falsely accept invalid YAML.
Instead the code should return an error/throw an exception, but I don't
know how to do this here.
So this is just the less optimal solution, avoiding a program abort.

