### PR TITLE
Remove I_STDLIB and I_STRING compile switches.

### DIFF
--- a/syck.h
+++ b/syck.h
@@ -1,10 +1,4 @@
 #include "config.h"
-#ifdef I_STDLIB
-#define HAVE_STDLIB_H
-#endif
-#ifdef I_STRING
-#define HAVE_STRING_H
-#endif
 
 /*
  * syck.h
@@ -26,12 +20,7 @@
 
 /* Unconditionally added as part of perl's headers anyway: */
 #include <stdlib.h>
-
-#ifdef HAVE_STRING_H
-# include <string.h>
-#else
-# include <strings.h>
-#endif
+#include <string.h>
 
 #ifdef HAVE_INTRINSICS_H
 # include <intrinsics.h>


### PR DESCRIPTION
On OpenBSD with Perl 5.28.1 the XS dynamic object is miscompiled
due to missing prototypes.  Using YAML::Syck results in a segmentation
fault.  The necessary header files stdlib.h and string.h are not
included as the defines I_STDLIB and I_STRING do not work anymore.
Perl has removed them from their config.h in 2017 in theses commits:
dd512de320cc50ddbfc3ce3ee4996367b911d983
d54fbe846a9f98aaae47d79e46490ecda6819fe0
As C before C89 is no longer supported by Perl, this module should not
do this either.  So remove the #ifdef around the #include.