### PR TITLE
syck.h: unconditionally include stdlib.h

### DIFF
--- a/syck.h
+++ b/syck.h
@@ -24,9 +24,8 @@
 #define SYCK_VERSION    "0.61"
 #define YAML_DOMAIN     "yaml.org,2002"
 
-#ifdef HAVE_STDLIB_H
-# include <stdlib.h>
-#endif
+/* Unconditionally added as part of perl's headers anyway: */
+#include <stdlib.h>
 
 #ifdef HAVE_STRING_H
 # include <string.h>


### PR DESCRIPTION
Perl itself does this now (in util.c), and not including stdlib.h
breaks compilation in stricter compilers, since they won't see
the free() or strtod().