### PR TITLE
Address memory corruption leading to 'str' value being set on empty keys

### DIFF
--- a/perl_syck.h
+++ b/perl_syck.h
@@ -177,9 +177,6 @@ yaml_syck_parser_handler
                 }
             } else if (strEQ( id, "null" )) {
                 sv = newSV(0);
-            } else if (strnEQ( id, "str", 3 )) {
-                sv = newSVpvn(n->data.str->ptr, n->data.str->len);
-                CHECK_UTF8;
             } else if (strEQ( id, "bool#yes" )) {
                 sv = newSVsv(&PL_sv_yes);
             } else if (strEQ( id, "bool#no" )) {

--- a/token.c
+++ b/token.c
@@ -1552,6 +1552,7 @@ Plain:
         int qidx = 0;
         int qcapa = 100;
         char *qstr = S_ALLOC_N( char, qcapa );
+        qstr[0] = '\0';
         SyckLevel *plvl;
         int parentIndent;
 
@@ -1804,6 +1805,7 @@ SingleQuote:
         int qidx = 0;
         int qcapa = 100;
         char *qstr = S_ALLOC_N( char, qcapa );
+        qstr[0] = '\0';
 
 SingleQuote2:
         YYTOKEN = YYCURSOR;
@@ -1962,6 +1964,7 @@ DoubleQuote:
         int qidx = 0;
         int qcapa = 100;
         char *qstr = S_ALLOC_N( char, qcapa );
+        qstr[0] = '\0';
 
 DoubleQuote2:
         YYTOKEN = YYCURSOR;
@@ -2232,6 +2235,7 @@ TransferMethod:
         int qidx = 0;
         int qcapa = 100;
         char *qstr = S_ALLOC_N( char, qcapa );
+        qstr[0] = '\0';
 
 TransferMethod2:
         YYTOKTMP = YYCURSOR;
@@ -2450,6 +2454,7 @@ ScalarBlock:
         SyckLevel *lvl = CURRENT_LEVEL();
         int parentIndent = -1;
 
+        qstr[0] = '\0';
         switch ( *yyt )
         {
             case '|': blockType = BLOCK_LIT; break;
@@ -2472,7 +2477,6 @@ ScalarBlock:
             }
         }
 
-        qstr[0] = '\0';
         YYTOKEN = YYCURSOR;
 
 ScalarBlock2:


### PR DESCRIPTION
When yaml is parsed, qstr is allocated
In cases when the keys point to empty values there is no value
copied to qstr and no null value is copied in

There may be a better check when the empty string is found.